### PR TITLE
 Added addTypeName flag to mockedResponses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,47 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/apollographql/apollo-test-utils.svg)](https://greenkeeper.io/)
 
-This is a very rudimentary package that currently only exports functions for mocking an Apollo Client network interface. Here's an example for how to use it:
+This is a very rudimentary package that currently only exports functions for mocking an Apollo Client network interface.
+
+## Installation
+npm
+```
+npm install --save-dev apollo-test-utils
+```
+yarn
+```
+yarn add --dev apollo-test-utils
+```
+
+## Usage
+
+### simple mocked NetworkInterface
+
+```js
+import ApolloClient from 'apollo-client';
+import gql from 'graphql-tag';
+import { mockNetworkInterface } from 'apollo-test-utils';
+
+const mockedResponse = {
+  request: {
+    query: gql`<put your query here>`,
+    variables: {
+      // query variables
+    },
+  },
+  result: [/* expected result */],
+};
+// mockNetworkInterface takes n mockedResponses as arguments or an array of those
+const mockedNetworkInterface = mockNetworkInterface( mockedResponse );
+const client = new ApolloClient({
+    networkInterface: mockedNetworkInterface,
+});
+
+client.query({ /* ... */ });
+
+```
+
+### Mock NetworkInterface with schema
 
 ```js
   import ApolloClient from 'apollo-client';
@@ -31,7 +71,28 @@ This is a very rudimentary package that currently only exports functions for moc
   });
 
   client.query({
-    query: gql`{ user { name } }`,
   });
 
 ```
+
+## Issues
+
+### Error: "No more mocked responses for the query ..." even though you provided the correct mocked response
+This is most likely due to ApolloClient adding ```__typename``` to your query.
+You can use the ```addTypeName``` flag in your MockedResponses to also add these names to the query:
+
+```js
+...
+const mockedResponse = {
+  request: {
+    query: gql`<put your query here>`,
+    variables: {
+      // query variables
+    },
+    addTypeName: true, // __typenames will now be added to your query
+  },
+  result: [/* expected result */],
+};
+...
+```
+You could use ```addTypenameToDocument```, from apollo-client, on your query to achieve the same effect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-test-utils",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "author": "Kamil Kisiela <kamil.kisiela@gmail.com>",
   "contributors": [

--- a/src/mocks/mockNetworkInterface.ts
+++ b/src/mocks/mockNetworkInterface.ts
@@ -6,6 +6,10 @@ import {
 } from 'apollo-client/transport/networkInterface';
 
 import {
+  addTypenameToDocument,
+} from 'apollo-client';
+
+import {
   ExecutionResult,
   DocumentNode,
   print,
@@ -35,6 +39,7 @@ export interface ParsedRequest {
   variables?: Object;
   query?: DocumentNode;
   debugName?: string;
+  addTypeName?: boolean;
 }
 
 export interface MockedResponse {
@@ -193,9 +198,11 @@ extends MockNetworkInterface implements BatchedNetworkInterface {
   }
 }
 
-
 function requestToKey(request: ParsedRequest): string {
-  const queryString = request.query && print(request.query);
+  const query = request.addTypeName
+    ? addTypenameToDocument( request.query )
+    : request.query;
+  const queryString = query && print(query);
 
   return JSON.stringify({
     variables: request.variables || {},

--- a/tests/mockNetworkInterface.ts
+++ b/tests/mockNetworkInterface.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import { omit, keys } from 'lodash';
 import { assert } from 'chai';
 
 import gql from 'graphql-tag';
@@ -6,6 +6,8 @@ import gql from 'graphql-tag';
 import {
   mockSubscriptionNetworkInterface,
   MockedSubscription,
+  mockNetworkInterface,
+  MockedResponse,
 } from '../src';
 
 describe('MockSubscriptionNetworkInterface', () => {
@@ -233,5 +235,46 @@ describe('MockSubscriptionNetworkInterface', () => {
     assert.throw(() => {
       networkInterface.fireResult(0);
     });
+  });
+});
+
+describe('mockNetworkInterace', () => {
+  const query = gql`
+      query UserInfo($name: String) {
+        user(name: $name) {
+          name
+        }
+      }`;
+  it( 'should not add typenames to queries when addTypeName option is false (/undefined)', () => {
+    const queryMock: MockedResponse = {
+      request: {
+        query: query,
+        variables: {
+          name: 'Edward Elric',
+        },
+      },
+      result: [],
+    };
+    const mockedNetworkInterface = mockNetworkInterface( queryMock );
+    const keysOfMockedResponses = keys(mockedNetworkInterface.mockedResponsesByKey );
+    assert.lengthOf( keysOfMockedResponses, 1 );
+    assert.notMatch(keysOfMockedResponses[0], /\_\_typename/g );
+  });
+
+  it( 'should add typenames to queries when addTypeName option is true', () => {
+    const queryMock: MockedResponse = {
+      request: {
+        query: query,
+        variables: {
+          name: 'Alphonse Elric',
+        },
+        addTypeName: true,
+      },
+      result: [],
+    };
+    const mockedNetworkInterface = mockNetworkInterface(queryMock);
+    const keysOfMockedResponses = keys(mockedNetworkInterface.mockedResponsesByKey);
+    assert.lengthOf(keysOfMockedResponses, 1);
+    assert.match(keysOfMockedResponses[0], /\_\_typename/g);
   });
 });


### PR DESCRIPTION
Fixed https://github.com/apollographql/apollo-test-utils/issues/24 mainly by updating the readme, but also provided an "addTypeName" flag to the mockedresponse so that one does not need to do this manually.